### PR TITLE
feat(stacks.api/stacks): implement `CacheStack` to using managed elasticache redis clusters

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -441,6 +441,7 @@ const apiStack = AwsCdkTsAppBuilder.build({
 		'flat',
 		'@cdklabs/cdk-validator-cfnguard',
 		'cdk-ec2-key-pair',
+		'cdk-redisdb',
 		`cdk8s@${crisiscleanup.package.tryResolveDependencyVersion('cdk8s')!}`,
 		`${CDK8sPlus}@${crisiscleanup.package.tryResolveDependencyVersion(
 			CDK8sPlus,

--- a/packages/stacks/api/.projen/deps.json
+++ b/packages/stacks/api/.projen/deps.json
@@ -138,6 +138,10 @@
       "type": "runtime"
     },
     {
+      "name": "cdk-redisdb",
+      "type": "runtime"
+    },
+    {
       "name": "cdk-sops-secrets",
       "type": "runtime"
     },

--- a/packages/stacks/api/.projen/tasks.json
+++ b/packages/stacks/api/.projen/tasks.json
@@ -177,13 +177,13 @@
           "exec": "pnpm update npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --upgrade --target=minor --filter=@types/flat,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,aws-cdk,esbuild,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,lint-staged,npm-check-updates,prettier,projen,ts-node,vitest,@aws-cdk/lambda-layer-kubectl-v27,@aws-quickstart/eks-blueprints,@cdklabs/cdk-validator-cfnguard,@kubecost/kubecost-eks-blueprints-addon,aws-cdk-lib,cdk-ec2-key-pair,cdk-pipelines-github,cdk-sops-secrets,constructs,defu,flat,zod"
+          "exec": "npm-check-updates --upgrade --target=minor --filter=@types/flat,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,aws-cdk,esbuild,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,lint-staged,npm-check-updates,prettier,projen,ts-node,vitest,@aws-cdk/lambda-layer-kubectl-v27,@aws-quickstart/eks-blueprints,@cdklabs/cdk-validator-cfnguard,@kubecost/kubecost-eks-blueprints-addon,aws-cdk-lib,cdk-ec2-key-pair,cdk-pipelines-github,cdk-redisdb,cdk-sops-secrets,constructs,defu,flat,zod"
         },
         {
           "exec": "pnpm i --no-frozen-lockfile"
         },
         {
-          "exec": "pnpm update @types/flat @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint lint-staged npm-check-updates prettier projen ts-node vitest @aws-cdk/lambda-layer-kubectl-v27 @aws-quickstart/eks-blueprints @cdklabs/cdk-validator-cfnguard @kubecost/kubecost-eks-blueprints-addon aws-cdk-lib cdk-ec2-key-pair cdk-pipelines-github cdk-sops-secrets constructs defu flat zod"
+          "exec": "pnpm update @types/flat @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint lint-staged npm-check-updates prettier projen ts-node vitest @aws-cdk/lambda-layer-kubectl-v27 @aws-quickstart/eks-blueprints @cdklabs/cdk-validator-cfnguard @kubecost/kubecost-eks-blueprints-addon aws-cdk-lib cdk-ec2-key-pair cdk-pipelines-github cdk-redisdb cdk-sops-secrets constructs defu flat zod"
         },
         {
           "exec": "npx projen"

--- a/packages/stacks/api/package.json
+++ b/packages/stacks/api/package.json
@@ -60,6 +60,7 @@
     "aws-cdk-lib": "^2.91.0",
     "cdk-ec2-key-pair": "^3.3.1",
     "cdk-pipelines-github": "^0.4.103",
+    "cdk-redisdb": "^0.0.37",
     "cdk-sops-secrets": "^1.2.250",
     "cdk8s": "2.42.0",
     "cdk8s-plus-27": "2.6.0",

--- a/packages/stacks/api/src/schema.ts
+++ b/packages/stacks/api/src/schema.ts
@@ -88,10 +88,39 @@ export const networkConfigSchema = z.object({
 
 export interface NetworkConfig extends z.infer<typeof networkConfigSchema> {}
 
+export const cacheConfigSchema = z.object({
+	enabled: z
+		.boolean()
+		.describe('Whether to create managed elasticache instance.')
+		.default(false),
+	nodeType: z
+		.string()
+		.describe('ElastiCache Node Type')
+		.default('cache.m7g.large'),
+	engineVersion: z.string().describe('Redis Engine Version').default('7.0'),
+	nodes: z.number().describe('Number of nodes to create.').default(1),
+	replicas: z.number().describe('Number of replicas to create.').default(1),
+	clusterMode: z
+		.boolean()
+		.describe('Enable redis cluster mode.')
+		.default(false),
+	memoryAutoscalingTarget: z
+		.number()
+		.min(10)
+		.max(100)
+		.optional()
+		.nullable()
+		.describe('Configure autoscaling target for cluster.')
+		.default(null),
+})
+
+export interface CacheConfig extends z.infer<typeof cacheConfigSchema> {}
+
 export const apiStackConfigSchema = z.object({
 	eks: eksConfigSchema.default({}).describe('EKS configuration.'),
 	database: databaseConfigSchema.default({ snapshotIdentifier: '' }),
 	network: networkConfigSchema.default({}),
+	cache: cacheConfigSchema.default({}),
 	codeStarConnectionArn: z.string().optional(),
 	kubecostToken: z.string().optional(),
 })

--- a/packages/stacks/api/src/stacks/cache.ts
+++ b/packages/stacks/api/src/stacks/cache.ts
@@ -1,0 +1,68 @@
+import * as cdk from 'aws-cdk-lib'
+import * as ec2 from 'aws-cdk-lib/aws-ec2'
+import type * as elasticache from 'aws-cdk-lib/aws-elasticache'
+import { RedisDB } from 'cdk-redisdb'
+import { type Construct } from 'constructs'
+import { type CacheConfig } from '../schema'
+
+export interface CacheProps extends CacheConfig {
+	vpc: ec2.IVpc
+}
+
+/**
+ * AWS Managed Elasticache Redis stack.
+ */
+export class CacheStack extends cdk.Stack {
+	readonly securityGroup: ec2.ISecurityGroup
+	readonly redis: RedisDB
+
+	constructor(
+		scope: Construct,
+		id: string,
+		props: CacheProps,
+		stackProps?: cdk.StackProps,
+	) {
+		super(scope, id, stackProps)
+
+		this.securityGroup = new ec2.SecurityGroup(this, id + '-security-group', {
+			vpc: props.vpc,
+			description: 'Security group for RedisDB',
+			allowAllOutbound: false,
+		})
+
+		this.securityGroup.addIngressRule(
+			ec2.Peer.ipv4(props.vpc.vpcCidrBlock),
+			ec2.Port.tcp(6379),
+			'Ingress within VPC',
+		)
+
+		this.securityGroup.addEgressRule(
+			ec2.Peer.ipv4(props.vpc.vpcCidrBlock),
+			ec2.Port.allTcp(),
+			'Egress within VPC',
+		)
+
+		this.redis = new RedisDB(this, id + '-redis', {
+			nodes: props.nodes,
+			nodeType: props.nodeType,
+			replicas: props.replicas,
+			...(typeof props.memoryAutoscalingTarget === 'number'
+				? { memoryAutoscalingTarget: props.memoryAutoscalingTarget }
+				: {}),
+			engineVersion: props.engineVersion,
+			existingVpc: props.vpc,
+			existingSecurityGroup: this.securityGroup,
+			atRestEncryptionEnabled: true,
+		})
+		if (!props.clusterMode) {
+			this.replicationGroup.addOverride(
+				'Properties.CacheParameterGroupName',
+				'default.redis7',
+			)
+		}
+	}
+
+	get replicationGroup(): elasticache.CfnReplicationGroup {
+		return this.redis.replicationGroup
+	}
+}

--- a/packages/stacks/api/src/stacks/data.ts
+++ b/packages/stacks/api/src/stacks/data.ts
@@ -95,12 +95,24 @@ export class Database extends Construct {
 			},
 			defaultDatabaseName: this.props.databaseName,
 			snapshotIdentifier: this.props.snapshotIdentifier,
+			...(this.props.performanceInsights
+				? {
+						monitoringInterval: cdk.Duration.minutes(1),
+				  }
+				: {}),
 		}
 		this.cluster = new rds.DatabaseClusterFromSnapshot(
 			this,
 			id + '-cluster',
 			clusterProps,
 		)
+		// enable devops guru
+		if (this.props.performanceInsights) {
+			cdk.Tags.of(this.cluster).add(
+				'devops-guru-default',
+				this.props.databaseName ?? 'crisiscleanup',
+			)
+		}
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,9 @@ importers:
       cdk-pipelines-github:
         specifier: ^0.4.103
         version: 0.4.103(aws-cdk-lib@2.91.0)(constructs@10.2.69)
+      cdk-redisdb:
+        specifier: ^0.0.37
+        version: 0.0.37(aws-cdk-lib@2.91.0)(constructs@10.2.69)
       cdk-sops-secrets:
         specifier: ^1.2.250
         version: 1.2.250(aws-cdk-lib@2.91.0)(constructs@10.2.69)
@@ -6327,6 +6330,19 @@ packages:
       - fast-json-patch
       - yaml
 
+  /cdk-redisdb@0.0.37(aws-cdk-lib@2.91.0)(constructs@10.2.69):
+    resolution:
+      {
+        integrity: sha512-o2h/JAlNMKc8V0pIKsObvJ5tD8wqaxk0ptQ/udYaklNUbPwDAB8bBHQ3Cn/uW4SIalSinNlokTB52qnl0HKKoQ==,
+      }
+    peerDependencies:
+      aws-cdk-lib: ^2.83.1
+      constructs: ^10.0.5
+    dependencies:
+      aws-cdk-lib: 2.91.0(constructs@10.2.69)
+      constructs: 10.2.69
+    dev: false
+
   /cdk-sops-secrets@1.2.250(aws-cdk-lib@2.91.0)(constructs@10.2.69):
     resolution:
       {
@@ -7633,7 +7649,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230817
+      typescript: 5.3.0-dev.20230818
     dev: true
 
   /duplexer@0.1.2:
@@ -14640,10 +14656,10 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.3.0-dev.20230817:
+  /typescript@5.3.0-dev.20230818:
     resolution:
       {
-        integrity: sha512-WbPb4NIGIcx8fQG4JPh54lALvzPUJTcDLCP9xVsrfOMrMAWswPqqekMZ7jVpasCOmYtC9e+oUCpW+jgVVcW7UQ==,
+        integrity: sha512-inkObfKw5TVieNQdO9vTAAzUIKV6i2bjqpC28j1knVWvcxaBLtNGrPgxGVnhWB/LQ5AjMLvgkCM58kkamkRObQ==,
       }
     engines: { node: '>=14.17' }
     hasBin: true


### PR DESCRIPTION
- feat(stacks.api): enable performance insights and devops guru based on props
- feat(stacks.api): add cdk-redisdb
- feat(stacks.api/schema): add cache config schema to api stack config schema
- feat(stacks.api/stacks): implement `CacheStack` for provisioning aws managed elasticache redis instance/cluster

Fixes #
