### PR TITLE
fix(construct.awscdk.github-pipeline): split node/pnpm setup, setup node during pre-published if needed

### DIFF
--- a/.github/workflows/deploy-maintenance-site.yml
+++ b/.github/workflows/deploy-maintenance-site.yml
@@ -119,6 +119,11 @@ jobs:
         run: |-
           echo ::add-mask::${{secrets.AWS_PIPELINE_ACCOUNT_ID}}
           echo ::add-mask::${{secrets.AWS_ACCOUNT_ID_PIPELINE}}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+        if: inputs.runner == 'self-hosted'
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@v1
         if: runner.arch == 'ARM64' || inputs.runner == 'self-hosted'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,6 +192,11 @@ jobs:
           echo ::add-mask::${{secrets.AWS_ACCOUNT_ID_DEVELOPMENT}}
           echo ::add-mask::${{secrets.AWS_ACCOUNT_ID_STAGING}}
           echo ::add-mask::${{secrets.AWS_ACCOUNT_ID_PRODUCTION}}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+        if: inputs.runner == 'self-hosted'
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@v1
         if: runner.arch == 'ARM64' || inputs.runner == 'self-hosted'

--- a/packages/construct/awscdk/github-pipeline/test/__snapshots__/workflow.spec.ts.snap
+++ b/packages/construct/awscdk/github-pipeline/test/__snapshots__/workflow.spec.ts.snap
@@ -89,6 +89,14 @@ exports[`GithubCodePipeline > builder has expected props 1`] = `
   ],
   "prePublishSteps": [
     {
+      "if": "inputs.runner == 'self-hosted'",
+      "name": "Setup Node",
+      "uses": "actions/setup-node@v3",
+      "with": {
+        "node-version": "18",
+      },
+    },
+    {
       "if": "runner.arch == 'ARM64' || inputs.runner == 'self-hosted'",
       "name": "Install AWS CLI",
       "uses": "unfor19/install-aws-cli-action@v1",
@@ -213,6 +221,14 @@ GithubCodePipeline {
       },
     ],
     "prePublishSteps": [
+      {
+        "if": "inputs.runner == 'self-hosted'",
+        "name": "Setup Node",
+        "uses": "actions/setup-node@v3",
+        "with": {
+          "node-version": "18",
+        },
+      },
       {
         "if": "runner.arch == 'ARM64' || inputs.runner == 'self-hosted'",
         "name": "Install AWS CLI",
@@ -372,6 +388,11 @@ jobs:
           echo ::add-mask::\${{secrets.AWS_ACCOUNT_ID_ALPHA}}
           echo ::add-mask::\${{secrets.AWS_ACCOUNT_ID_BETA}}
           echo ::add-mask::\${{secrets.AWS_ACCOUNT_ID_DELTA}}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: \\"18\\"
+        if: inputs.runner == 'self-hosted'
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@v1
         if: runner.arch == 'ARM64' || inputs.runner == 'self-hosted'

--- a/packages/construct/awscdk/github-pipeline/test/workflow.spec.ts
+++ b/packages/construct/awscdk/github-pipeline/test/workflow.spec.ts
@@ -63,7 +63,8 @@ describe('GithubCodePipeline', () => {
 			.installHelm('3.6.3')
 			.installAwsCli('2')
 			.installSops('3.7.3')
-			.installPnpm('18', '8')
+			.installNode('18', 'pnpm')
+			.installPnpm('8')
 			.publishPostStep({
 				name: 'My Custom post publish step',
 				run: 'echo "hello world"',


### PR DESCRIPTION
- fix(construct.awscdk.github-pipeline): split node/pnpm methods, setup node on during pre-publish if needed
- test(construct.awscdk.github-pipeline): update unit tests
- ci(deploy): update synthesized workflows

Fixes #
