### PR TITLE
fix(stacks.api): coredns addon options, prevent secrets-store-csi from trying to schedule on fargate nodes

### DIFF
--- a/packages/stacks/api/src/cluster.ts
+++ b/packages/stacks/api/src/cluster.ts
@@ -50,7 +50,7 @@ export const getCoreAddons = (
 			enablePrefixDelegation: true,
 			version: addonConfig.vpcCniVersion,
 		}),
-		new blueprints.addons.CoreDnsAddOn(addonConfig.coreDnsVersion),
+		new blueprints.addons.CoreDnsAddOn({ version: addonConfig.coreDnsVersion }),
 		new blueprints.addons.KubeProxyAddOn(addonConfig.kubeProxyVersion),
 	]
 }

--- a/packages/stacks/api/test/__snapshots__/main.spec.ts.snap
+++ b/packages/stacks/api/test/__snapshots__/main.spec.ts.snap
@@ -2310,7 +2310,7 @@ exports[`Snapshot 1`] = `
           ],
         },
         "Timeout": "900s",
-        "Values": "{\\"grpcSupportedProviders\\":\\"aws\\",\\"syncSecret\\":{\\"enabled\\":\\"true\\"}}",
+        "Values": "{\\"grpcSupportedProviders\\":\\"aws\\",\\"syncSecret\\":{\\"enabled\\":\\"true\\"},\\"linux\\":{\\"affinity\\":{\\"nodeAffinity\\":{\\"requiredDuringSchedulingIgnoredDuringExecution\\":{\\"nodeSelectorTerms\\":[{\\"matchExpressions\\":[{\\"key\\":\\"eks.amazonaws.com/compute-type\\",\\"operator\\":\\"NotIn\\",\\"values\\":[\\"fargate\\"]}]}]}}}}}",
         "Version": "1.3.4",
         "Wait": true,
       },


### PR DESCRIPTION
- fix(stacks.api): coredns addon now expects options object
- fix(stacks.api): prevent secrets-store csi from trying to schedule on fargate nodes

Fixes #
