### PR TITLE
feat(stacks.api): Pipeline `stackBuilder` callback, add ARC addons to cluster

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,7 @@ jobs:
       asset-hash25: ${{steps.publish.outputs.asset-hash25}}
       asset-hash26: ${{steps.publish.outputs.asset-hash26}}
       asset-hash27: ${{steps.publish.outputs.asset-hash27}}
+      asset-hash28: ${{steps.publish.outputs.asset-hash28}}
       asset-hash3: ${{steps.publish.outputs.asset-hash3}}
       asset-hash4: ${{steps.publish.outputs.asset-hash4}}
       asset-hash5: ${{steps.publish.outputs.asset-hash5}}
@@ -190,7 +191,7 @@ jobs:
       - name: Publish
         id: publish
         run: >-
-          targets="./cdk.out/publish-Assets-FileAsset1-step.sh,./cdk.out/publish-Assets-FileAsset10-step.sh,./cdk.out/publish-Assets-FileAsset11-step.sh,./cdk.out/publish-Assets-FileAsset12-step.sh,./cdk.out/publish-Assets-FileAsset13-step.sh,./cdk.out/publish-Assets-FileAsset14-step.sh,./cdk.out/publish-Assets-FileAsset15-step.sh,./cdk.out/publish-Assets-FileAsset16-step.sh,./cdk.out/publish-Assets-FileAsset17-step.sh,./cdk.out/publish-Assets-FileAsset18-step.sh,./cdk.out/publish-Assets-FileAsset19-step.sh,./cdk.out/publish-Assets-FileAsset2-step.sh,./cdk.out/publish-Assets-FileAsset20-step.sh,./cdk.out/publish-Assets-FileAsset21-step.sh,./cdk.out/publish-Assets-FileAsset22-step.sh,./cdk.out/publish-Assets-FileAsset23-step.sh,./cdk.out/publish-Assets-FileAsset24-step.sh,./cdk.out/publish-Assets-FileAsset25-step.sh,./cdk.out/publish-Assets-FileAsset26-step.sh,./cdk.out/publish-Assets-FileAsset27-step.sh,./cdk.out/publish-Assets-FileAsset3-step.sh,./cdk.out/publish-Assets-FileAsset4-step.sh,./cdk.out/publish-Assets-FileAsset5-step.sh,./cdk.out/publish-Assets-FileAsset6-step.sh,./cdk.out/publish-Assets-FileAsset7-step.sh,./cdk.out/publish-Assets-FileAsset8-step.sh,./cdk.out/publish-Assets-FileAsset9-step.sh"
+          targets="./cdk.out/publish-Assets-FileAsset1-step.sh,./cdk.out/publish-Assets-FileAsset10-step.sh,./cdk.out/publish-Assets-FileAsset11-step.sh,./cdk.out/publish-Assets-FileAsset12-step.sh,./cdk.out/publish-Assets-FileAsset13-step.sh,./cdk.out/publish-Assets-FileAsset14-step.sh,./cdk.out/publish-Assets-FileAsset15-step.sh,./cdk.out/publish-Assets-FileAsset16-step.sh,./cdk.out/publish-Assets-FileAsset17-step.sh,./cdk.out/publish-Assets-FileAsset18-step.sh,./cdk.out/publish-Assets-FileAsset19-step.sh,./cdk.out/publish-Assets-FileAsset2-step.sh,./cdk.out/publish-Assets-FileAsset20-step.sh,./cdk.out/publish-Assets-FileAsset21-step.sh,./cdk.out/publish-Assets-FileAsset22-step.sh,./cdk.out/publish-Assets-FileAsset23-step.sh,./cdk.out/publish-Assets-FileAsset24-step.sh,./cdk.out/publish-Assets-FileAsset25-step.sh,./cdk.out/publish-Assets-FileAsset26-step.sh,./cdk.out/publish-Assets-FileAsset27-step.sh,./cdk.out/publish-Assets-FileAsset28-step.sh,./cdk.out/publish-Assets-FileAsset3-step.sh,./cdk.out/publish-Assets-FileAsset4-step.sh,./cdk.out/publish-Assets-FileAsset5-step.sh,./cdk.out/publish-Assets-FileAsset6-step.sh,./cdk.out/publish-Assets-FileAsset7-step.sh,./cdk.out/publish-Assets-FileAsset8-step.sh,./cdk.out/publish-Assets-FileAsset9-step.sh"
 
           echo -n "$targets" | xargs -r -d',' -t -n1 -P2 /bin/bash
   deploy-development-development-network-deploy:

--- a/packages/stacks/api/src/addons/crisiscleanup.ts
+++ b/packages/stacks/api/src/addons/crisiscleanup.ts
@@ -72,7 +72,10 @@ export class CrisisCleanupAddOn implements blueprints.ClusterAddOn {
 					defu(values, saProps),
 				]),
 			) as CrisisCleanupChartProps['celery'],
-			adminWebsocket: defu(chartConfig.adminWebsocket, saProps),
+			adminWebsocket: defu(
+				chartConfig.adminWebsocket,
+				saProps,
+			) as CrisisCleanupChartProps['adminWebsocket'],
 		})
 
 		let secretName = this.props.secretName

--- a/packages/stacks/api/src/main.ts
+++ b/packages/stacks/api/src/main.ts
@@ -55,23 +55,27 @@ const pipeline = Pipeline.builder({
 })
 	.target({
 		name: 'development',
-		stackBuilder: blueprints.EksBlueprint.builder()
-			.clone()
-			.addOns(new RedisStackAddOn()),
+		stackBuilder: (builder) => builder.addOns(new RedisStackAddOn()),
 		config: config.$env!.development as unknown as CrisisCleanupConfig,
 		secretsProvider: devSecretsProvider,
 	})
 	.target({
 		name: 'staging',
-		stackBuilder: blueprints.EksBlueprint.builder()
-			.clone()
-			.addOns(new RedisStackAddOn()),
+		stackBuilder: (builder) => builder.addOns(new RedisStackAddOn()),
 		config: config.$env!.staging as unknown as CrisisCleanupConfig,
 		secretsProvider: stagingSecretsProvider,
 	})
 	.target({
 		name: 'production',
-		stackBuilder: blueprints.EksBlueprint.builder().clone(),
+		stackBuilder: (builder, builderConfig) =>
+			builder
+				.enableControlPlaneLogTypes(
+					<blueprints.ControlPlaneLogType>'api',
+					<blueprints.ControlPlaneLogType>'controllerManager',
+					<blueprints.ControlPlaneLogType>'audit',
+					<blueprints.ControlPlaneLogType>'authenticator',
+					<blueprints.ControlPlaneLogType>'scheduler',
+				),
 		config: config.$env!.production as unknown as CrisisCleanupConfig,
 		secretsProvider: prodSecretsProvider,
 	})


### PR DESCRIPTION
- fix(stacks.api/addons): admin websocket config types
- feat(stacks.api/pipeline): make `stackBuilder` a callback with account scoped cluster
- feat(stacks.api): update `stackBuilder` in main entry, enable production cluster logs
- feat(stacks.api): add `ARCScaleSetController` and `ARCScaleSet` to production cluster
- ci(deploy): update synthesized deploy workflow

Fixes #
