### PR TITLE
feat(stacks.api): Kube Prom Stack Node affinity, ARC scale set controller metrics

### DIFF
--- a/packages/stacks/api/src/cluster.ts
+++ b/packages/stacks/api/src/cluster.ts
@@ -18,6 +18,18 @@ enum Label {
 	COMPUTE_TYPE = 'eks.amazonaws.com/compute-type',
 }
 
+export const noFargateNodeAffinitySelector = {
+	// do not allow scheduling on fargate
+	// (it does not support daemon sets)
+	matchExpressions: [
+		{
+			key: Label.COMPUTE_TYPE,
+			operator: 'NotIn',
+			values: ['fargate'],
+		},
+	],
+}
+
 export const buildSecretStoreAddon = () =>
 	new blueprints.SecretsStoreAddOn({
 		syncSecrets: true,
@@ -26,19 +38,7 @@ export const buildSecretStoreAddon = () =>
 				affinity: {
 					nodeAffinity: {
 						requiredDuringSchedulingIgnoredDuringExecution: {
-							nodeSelectorTerms: [
-								{
-									// do not allow scheduling on fargate
-									// (it does not support daemon sets)
-									matchExpressions: [
-										{
-											key: Label.COMPUTE_TYPE,
-											operator: 'NotIn',
-											values: ['fargate'],
-										},
-									],
-								},
-							],
+							nodeSelectorTerms: [noFargateNodeAffinitySelector],
 						},
 					},
 				},

--- a/packages/stacks/api/src/main.ts
+++ b/packages/stacks/api/src/main.ts
@@ -13,6 +13,7 @@ import {
 	ARCScaleSetController,
 	ScaleSetContainer,
 } from './addons'
+import { noFargateNodeAffinitySelector } from './cluster.ts'
 import { Pipeline } from './pipeline'
 import { SopsSecretProvider } from './secrets'
 
@@ -99,7 +100,21 @@ const pipeline = Pipeline.builder({
 						},
 					}),
 				)
-				.addOns(new KubePrometheusStackAddOn()),
+				.addOns(
+					new KubePrometheusStackAddOn({
+						values: {
+							prometheusOperator: {
+								affinity: {
+									nodeAffinity: {
+										requiredDuringSchedulingIgnoredDuringExecution: {
+											nodeSelectorTerms: [noFargateNodeAffinitySelector],
+										},
+									},
+								},
+							},
+						},
+					}),
+				),
 		config: config.$env!.production as unknown as CrisisCleanupConfig,
 		secretsProvider: prodSecretsProvider,
 	})

--- a/packages/stacks/api/src/main.ts
+++ b/packages/stacks/api/src/main.ts
@@ -84,7 +84,15 @@ const pipeline = Pipeline.builder({
 					<blueprints.ControlPlaneLogType>'scheduler',
 				)
 				.addOns(
-					new ARCScaleSetController(),
+					new ARCScaleSetController({
+						values: {
+							metrics: {
+								controllerManagerAddr: ':8080',
+								listenerAddr: ':8080',
+								listenerEndpoint: '/metrics',
+							},
+						},
+					}),
 					new ARCScaleSet({
 						minRunners: builderConfig.apiStack!.arc.minRunners ?? undefined,
 						maxRunners: builderConfig.apiStack!.arc.maxRunners ?? undefined,


### PR DESCRIPTION
- feat(stacks.api/cluster): extract `noFargateNodeAffinitySelector`
- fix(stacks.api): apply noFargate affinity selector to kube-stack-prometheus
- feat(api.stack): enable arc scale set controller metrics

Fixes #
