### PR TITLE
fix(stacks.web): split install/build deploy steps and use working-directory

### DIFF
--- a/.github/workflows/deploy-crisiscleanup-site.yml
+++ b/.github/workflows/deploy-crisiscleanup-site.yml
@@ -87,7 +87,11 @@ jobs:
           repository: CrisisCleanup/crisiscleanup-4-web
           path: .crisiscleanup-4-web
       - name: Build Web
-        run: pushd .crisiscleanup-4-web && pnpm install && pnpm build:app
+        working-directory: .crisiscleanup-4-web
+        run: pnpm build:app
+      - name: Install Web
+        working-directory: .crisiscleanup-4-web
+        run: pnpm install
       - name: Authenticate Via OIDC Role
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:

--- a/packages/construct/awscdk/github-pipeline/src/pipeline-stack.ts
+++ b/packages/construct/awscdk/github-pipeline/src/pipeline-stack.ts
@@ -51,6 +51,13 @@ interface GithubCodePipelineCreateProps extends PipelineBuildProps {
 	oidcRoleName?: string
 }
 
+interface PipelineStep extends ghpipelines.JobStep {
+	/**
+	 * Working directory to use.
+	 */
+	workingDirectory?: string
+}
+
 /**
  * Builder for a GitHub CodePipeline.
  */
@@ -206,7 +213,7 @@ export class GithubCodePipeline {
 	 * Add pre-build step(s) to the synth step.
 	 * @param step The step(s) to add.
 	 */
-	synthPreStep(...step: ghpipelines.JobStep[]) {
+	synthPreStep(...step: PipelineStep[]) {
 		return this.clone({
 			preBuildSteps: step,
 		})
@@ -216,9 +223,19 @@ export class GithubCodePipeline {
 	 * Add post-build step(s) to the synth step.
 	 * @param step The step(s) to add.
 	 */
-	synthPostStep(...step: ghpipelines.JobStep[]) {
+	synthPostStep(...step: PipelineStep[]) {
 		return this.clone({
 			postBuildSteps: step,
+		})
+	}
+
+	/**
+	 * Add patch callback.
+	 * @param patcher factory for creating patches.
+	 */
+	patch(patcher: WorkflowPatcher) {
+		return this.clone({
+			patchers: [patcher],
 		})
 	}
 
@@ -239,9 +256,7 @@ export class GithubCodePipeline {
 			if (!isSynthJob) return undefined
 			return patcher.bind(this)(key, value)
 		}
-		return this.clone({
-			patchers: [synthPatcher],
-		})
+		return this.patch(synthPatcher)
 	}
 
 	/**

--- a/packages/stacks/web/src/main.ts
+++ b/packages/stacks/web/src/main.ts
@@ -104,8 +104,14 @@ const pipeline = GithubCodePipeline.create({
 		},
 	})
 	.synthPreStep({
+		name: 'Install Web',
+		workingDirectory: '.crisiscleanup-4-web',
+		run: 'pnpm install',
+	})
+	.synthPreStep({
 		name: 'Build Web',
-		run: 'pushd .crisiscleanup-4-web && pnpm install && pnpm build:app',
+		workingDirectory: '.crisiscleanup-4-web',
+		run: 'pnpm build:app',
 	})
 	.synthCheckout({
 		ref: 'master',


### PR DESCRIPTION
- feat(construct.awscdk.github-pipeline): extend `JobStep` interface with `workingDirectory`, add public `patch` method
- feat(stacks.web): split web install and build steps, use `workingDirectory`
- ci(stacks.web): update deploy workflow

Fixes #
