### PR TITLE
fix(arc): add python-dev back as dependency in arc image

### DIFF
--- a/arc-runner/Dockerfile
+++ b/arc-runner/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update -y \
   parallel \
   python3-pip \
   python3-venv \
+  python-dev \
   rsync \
   shellcheck \
   sudo \

--- a/arc-runner/docker-bake.hcl
+++ b/arc-runner/docker-bake.hcl
@@ -1,5 +1,5 @@
 target "default" {
   dockerfile = "Dockerfile"
-  tags = ["ghcr.io/crisiscleanup/runner:v2.311.0"]
+  tags = ["ghcr.io/crisiscleanup/runner:v2.311.0-1"]
   platforms = ["linux/arm64"]
 }


### PR DESCRIPTION
Signed-off-by: Braden Mars <bradenmars@bradenmars.me>

Fixes #
