### PR TITLE
feat: Support RDS cluster from scratch + snapshot, prepare production-au by adding environment to config schema

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -202,6 +202,7 @@ export const Environment = z.enum([
 	'development',
 	'staging',
 	'production',
+	'production-au',
 	'test',
 ])
 export type Stage = z.infer<typeof Environment>

--- a/packages/stacks/api/src/schema.ts
+++ b/packages/stacks/api/src/schema.ts
@@ -50,6 +50,8 @@ export const databaseConfigSchema = z.object({
 	databaseName: z.string().optional().nullable().default(null),
 	snapshotIdentifier: z
 		.string()
+		.nullable()
+		.default(null)
 		.describe('Snapshot identifier to restore from.'),
 	engineVersion: z
 		.string()

--- a/packages/stacks/api/src/stacks/data.ts
+++ b/packages/stacks/api/src/stacks/data.ts
@@ -123,9 +123,6 @@ export class Database extends Construct {
 		if (this.props.snapshotIdentifier) {
 			clusterProps = {
 				...baseClusterProps,
-				storageType: this.props.ioOptimized
-					? rds.DBClusterStorageType.AURORA_IOPT1
-					: DBClusterStorageType.AURORA,
 				snapshotIdentifier: this.props.snapshotIdentifier,
 				snapshotCredentials: rds.SnapshotCredentials.fromGeneratedSecret(
 					this.props.username ?? 'postgres',
@@ -139,6 +136,9 @@ export class Database extends Construct {
 		} else {
 			clusterProps = {
 				...baseClusterProps,
+				storageType: this.props.ioOptimized
+					? rds.DBClusterStorageType.AURORA_IOPT1
+					: DBClusterStorageType.AURORA,
 				credentials: this.props.credentialsSecret
 					? rds.Credentials.fromSecret(
 							this.props.credentialsSecret,


### PR DESCRIPTION
- feat(stacks.api): support creating rds cluster both from snapshot and from scratch
- feat(stacks.api): allow snapshotIdentifier to be nullable in database config
- fix(stacks.api): set storageType when creating from scratch, not from snapshot
- feat(config.schema): add production-au to config schema environments

Fixes #
