### PR TITLE
feat(stacks.api/addons): upgrade arc charts to v0.8.1

### DIFF
--- a/packages/stacks/api/src/addons/arc.ts
+++ b/packages/stacks/api/src/addons/arc.ts
@@ -91,7 +91,7 @@ const scaleSetControllerDefaultProps: blueprints.HelmAddOnProps &
 		'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
 	release: 'arc',
 	namespace: 'arc-systems',
-	version: '0.7.0',
+	version: '0.8.1',
 	values: {},
 }
 


### PR DESCRIPTION
Updates arc charts to latest v0.8.1
