### PR TITLE
feat(arc): update arc runner image to v2.314.1, update gh-runner-scale-set chart version

### DIFF
--- a/arc-runner/Dockerfile
+++ b/arc-runner/Dockerfile
@@ -3,12 +3,12 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
 # Replace value with the latest runner release version
 # source: https://github.com/actions/runner/releases
 # ex: 2.303.0
-ARG RUNNER_VERSION="2.311.0"
+ARG RUNNER_VERSION="2.314.1"
 ARG RUNNER_ARCH="arm64"
 # Replace value with the latest runner-container-hooks release version
 # source: https://github.com/actions/runner-container-hooks/releases
 # ex: 0.3.1
-ARG RUNNER_CONTAINER_HOOKS_VERSION="0.5.0"
+ARG RUNNER_CONTAINER_HOOKS_VERSION="0.5.1"
 
 ARG TARGETPLATFORM
 ARG TARGETOS
@@ -17,9 +17,9 @@ ARG RUNNER_VERSION
 
 # Docker and Docker Compose arguments
 ARG CHANNEL=stable
-ARG DOCKER_VERSION=24.0.6
-ARG BUILDX_VERSION=0.11.2
-ARG DOCKER_COMPOSE_VERSION=v2.20.0
+ARG DOCKER_VERSION=25.0.2
+ARG BUILDX_VERSION=0.12.1
+ARG DOCKER_COMPOSE_VERSION=v2.24.6
 ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121

--- a/arc-runner/docker-bake.hcl
+++ b/arc-runner/docker-bake.hcl
@@ -1,5 +1,5 @@
 target "default" {
   dockerfile = "Dockerfile"
-  tags = ["ghcr.io/crisiscleanup/runner:v2.311.0"]
+  tags = ["ghcr.io/crisiscleanup/runner:v2.314.1"]
   platforms = ["linux/arm64"]
 }

--- a/packages/stacks/api/src/addons/arc.ts
+++ b/packages/stacks/api/src/addons/arc.ts
@@ -91,7 +91,7 @@ const scaleSetControllerDefaultProps: blueprints.HelmAddOnProps &
 		'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
 	release: 'arc',
 	namespace: 'arc-systems',
-	version: '0.8.1',
+	version: '0.8.3',
 	values: {},
 }
 


### PR DESCRIPTION
- feat(arc-runner): update arc runner image to 2.314.1, hooks, docker versions
- feat(stacks.api/addons/arc): update gha-runner-scale-set to v0.8.3

Fixes #
