### PR TITLE
fix(construct.awscdk.cloudfront-url-rewrite): disable eslint no-var for cloudfront js v1 compatibility

### DIFF
--- a/packages/construct/awscdk/cloudfront-url-rewrite/src/handler.function.ts
+++ b/packages/construct/awscdk/cloudfront-url-rewrite/src/handler.function.ts
@@ -1,21 +1,22 @@
+/* eslint-disable no-var */
 import type { CloudFrontFunctionsEvent } from 'aws-lambda'
 
-const FROM_HOSTNAME = '<FROM_HOSTNAME>'
-const REDIRECT_URI_PATTERN = new RegExp('<REDIRECT_URI_PATTERN>', 'g')
-const TO_HOSTNAME = '<TO_HOSTNAME>'
-const TARGET_URI_PATTERN = '<TARGET_URI_PATTERN>'
+var FROM_HOSTNAME = '<FROM_HOSTNAME>'
+var REDIRECT_URI_PATTERN = new RegExp('<REDIRECT_URI_PATTERN>', 'g')
+var TO_HOSTNAME = '<TO_HOSTNAME>'
+var TARGET_URI_PATTERN = '<TARGET_URI_PATTERN>'
 
 /**
  * cloudfront-js supports a limited subset of javascript/ecma features.
  */
 // eslint-disable-next-line @typescript-eslint/require-await,@typescript-eslint/no-unused-vars
 function handler(event: CloudFrontFunctionsEvent) {
-	const request = event.request
-	const headers = request.headers
-	const uri = request.uri
+	var request = event.request
+	var headers = request.headers
+	var uri = request.uri
 
-	const hostParams = headers.host
-	let host = ''
+	var hostParams = headers.host
+	var host = ''
 	if (hostParams && hostParams.value) {
 		host = hostParams.value
 	}
@@ -24,8 +25,8 @@ function handler(event: CloudFrontFunctionsEvent) {
 		return request
 	}
 
-	const newUri = uri.replace(REDIRECT_URI_PATTERN, TARGET_URI_PATTERN)
-	const newUrl = `https://${TO_HOSTNAME}${newUri}`
+	var newUri = uri.replace(REDIRECT_URI_PATTERN, TARGET_URI_PATTERN)
+	var newUrl = `https://${TO_HOSTNAME}${newUri}`
 	return {
 		statusCode: 301,
 		statusDescription: 'Moved Permanently',

--- a/packages/construct/awscdk/cloudfront-url-rewrite/test/__snapshots__/cloudfront-url-rewrite.spec.ts.snap
+++ b/packages/construct/awscdk/cloudfront-url-rewrite/test/__snapshots__/cloudfront-url-rewrite.spec.ts.snap
@@ -77,19 +77,19 @@ var REDIRECT_URI_PATTERN = new RegExp(\\"^/oldpath/(.*)\\", \\"g\\");
 var TO_HOSTNAME = \\"new.example.com\\";
 var TARGET_URI_PATTERN = \\"/newpath/$1\\";
 function handler(event) {
-  const request = event.request;
-  const headers = request.headers;
-  const uri = request.uri;
-  const hostParams = headers.host;
-  let host = \\"\\";
+  var request = event.request;
+  var headers = request.headers;
+  var uri = request.uri;
+  var hostParams = headers.host;
+  var host = \\"\\";
   if (hostParams && hostParams.value) {
     host = hostParams.value;
   }
   if (!host || host !== FROM_HOSTNAME) {
     return request;
   }
-  const newUri = uri.replace(REDIRECT_URI_PATTERN, TARGET_URI_PATTERN);
-  const newUrl = \`https://\${TO_HOSTNAME}\${newUri}\`;
+  var newUri = uri.replace(REDIRECT_URI_PATTERN, TARGET_URI_PATTERN);
+  var newUrl = \`https://\${TO_HOSTNAME}\${newUri}\`;
   return {
     statusCode: 301,
     statusDescription: \\"Moved Permanently\\",


### PR DESCRIPTION
Signed-off-by: Braden Mars <bradenmars@bradenmars.me>

Fixes #
