### PR TITLE
feat(arc): update arc runner version, update chart to v0.10.1

### DIFF
--- a/arc-runner/Dockerfile
+++ b/arc-runner/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy as build
 # Replace value with the latest runner release version
 # source: https://github.com/actions/runner/releases
 # ex: 2.303.0
-ARG RUNNER_VERSION="2.320.0"
+ARG RUNNER_VERSION="2.321.0"
 ARG RUNNER_ARCH="arm64"
 # Replace value with the latest runner-container-hooks release version
 # source: https://github.com/actions/runner-container-hooks/releases
@@ -17,9 +17,9 @@ ARG RUNNER_VERSION
 
 # Docker and Docker Compose arguments
 ARG CHANNEL=stable
-ARG DOCKER_VERSION=27.1.1
-ARG BUILDX_VERSION=0.17.1
-ARG DOCKER_COMPOSE_VERSION=v2.30.0
+ARG DOCKER_VERSION=27.3.1
+ARG BUILDX_VERSION=0.18.0
+ARG DOCKER_COMPOSE_VERSION=v2.32.1
 ARG DUMB_INIT_VERSION=1.2.5
 ARG RUNNER_USER_UID=1001
 ARG DOCKER_GROUP_GID=121

--- a/arc-runner/docker-bake.hcl
+++ b/arc-runner/docker-bake.hcl
@@ -1,5 +1,5 @@
 target "default" {
   dockerfile = "Dockerfile"
-  tags = ["ghcr.io/crisiscleanup/runner:v2.320.0"]
+  tags = ["ghcr.io/crisiscleanup/runner:v2.321.0"]
   platforms = ["linux/arm64"]
 }

--- a/packages/stacks/api/src/addons/arc.ts
+++ b/packages/stacks/api/src/addons/arc.ts
@@ -91,7 +91,7 @@ const scaleSetControllerDefaultProps: blueprints.HelmAddOnProps &
 		'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
 	release: 'arc',
 	namespace: 'arc-systems',
-	version: '0.9.2',
+	version: '0.10.1',
 	values: {},
 }
 


### PR DESCRIPTION
- feat(arc): bump to v2.321, update docker/buildx/ocmpose versions
- feat(stacks.api/addons/arc): update helm chart to v0.10.1

Fixes #
