### PR TITLE
feat(stacks.api): add parameter group for Aurora PostgreSQL

### DIFF
--- a/packages/stacks/api/src/stacks/data.ts
+++ b/packages/stacks/api/src/stacks/data.ts
@@ -70,6 +70,17 @@ export class Database extends Construct {
 			}
 		}
 
+		const parameterGroup = new rds.ParameterGroup(this, id + '-parameter-group', {
+			engine: rds.DatabaseClusterEngine.auroraPostgres({
+			  version: engineVersion,
+			}),
+			parameters: {
+			  'shared_preload_libraries': 'pg_cron,pg_stat_statements',
+			  'cron.database_name': props.databaseName || 'crisiscleanup',
+			},
+		  });
+		  
+
 		const updateBehavior =
 			readers.length >= 1
 				? rds.InstanceUpdateBehaviour.ROLLING
@@ -82,6 +93,7 @@ export class Database extends Construct {
 				subnetType,
 			},
 			securityGroups: [this.securityGroup],
+			parameterGroup,
 			iamAuthentication: true,
 			port: 5432,
 			// WARNING:

--- a/packages/stacks/api/src/stacks/data.ts
+++ b/packages/stacks/api/src/stacks/data.ts
@@ -70,16 +70,19 @@ export class Database extends Construct {
 			}
 		}
 
-		const parameterGroup = new rds.ParameterGroup(this, id + '-parameter-group', {
-			engine: rds.DatabaseClusterEngine.auroraPostgres({
-			  version: engineVersion,
-			}),
-			parameters: {
-			  'shared_preload_libraries': 'pg_cron,pg_stat_statements',
-			  'cron.database_name': props.databaseName || 'crisiscleanup',
+		const parameterGroup = new rds.ParameterGroup(
+			this,
+			id + '-parameter-group',
+			{
+				engine: rds.DatabaseClusterEngine.auroraPostgres({
+					version: engineVersion,
+				}),
+				parameters: {
+					shared_preload_libraries: 'pg_cron,pg_stat_statements',
+					'cron.database_name': props.databaseName || 'crisiscleanup',
+				},
 			},
-		  });
-		  
+		)
 
 		const updateBehavior =
 			readers.length >= 1

--- a/packages/stacks/api/test/__snapshots__/data.spec.ts.snap
+++ b/packages/stacks/api/test/__snapshots__/data.spec.ts.snap
@@ -586,7 +586,9 @@ exports[`DataStack > renders expected template with defaults 1`] = `
       "Properties": {
         "BackupRetentionPeriod": 1,
         "CopyTagsToSnapshot": true,
-        "DBClusterParameterGroupName": "default.aurora-postgresql15",
+        "DBClusterParameterGroupName": {
+          "Ref": "testdatabasedatabasetestdatabasedatabaseparametergroupAC757BA0",
+        },
         "DBSubnetGroupName": {
           "Ref": "testdatabasedatabasetestdatabasedatabaseclusterSubnets5240EB31",
         },
@@ -734,6 +736,17 @@ exports[`DataStack > renders expected template with defaults 1`] = `
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Delete",
+    },
+    "testdatabasedatabasetestdatabasedatabaseparametergroupAC757BA0": {
+      "Properties": {
+        "Description": "Cluster parameter group for aurora-postgresql15",
+        "Family": "aurora-postgresql15",
+        "Parameters": {
+          "cron.database_name": "crisiscleanup",
+          "shared_preload_libraries": "pg_cron,pg_stat_statements",
+        },
+      },
+      "Type": "AWS::RDS::DBClusterParameterGroup",
     },
     "testdatabasedatabasetestdatabasedatabasesecuritygroup6CD4AEDA": {
       "Properties": {
@@ -1424,7 +1437,9 @@ exports[`DataStack > renders expected template with multiple replicas 1`] = `
       "Properties": {
         "BackupRetentionPeriod": 1,
         "CopyTagsToSnapshot": true,
-        "DBClusterParameterGroupName": "default.aurora-postgresql15",
+        "DBClusterParameterGroupName": {
+          "Ref": "testdatabasereplicasdatabasetestdatabasereplicasdatabaseparametergroup73CE779D",
+        },
         "DBSubnetGroupName": {
           "Ref": "testdatabasereplicasdatabasetestdatabasereplicasdatabaseclusterSubnets3BBCF632",
         },
@@ -1614,6 +1629,17 @@ exports[`DataStack > renders expected template with multiple replicas 1`] = `
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Delete",
+    },
+    "testdatabasereplicasdatabasetestdatabasereplicasdatabaseparametergroup73CE779D": {
+      "Properties": {
+        "Description": "Cluster parameter group for aurora-postgresql15",
+        "Family": "aurora-postgresql15",
+        "Parameters": {
+          "cron.database_name": "crisiscleanup",
+          "shared_preload_libraries": "pg_cron,pg_stat_statements",
+        },
+      },
+      "Type": "AWS::RDS::DBClusterParameterGroup",
     },
     "testdatabasereplicasdatabasetestdatabasereplicasdatabasesecuritygroupF326E969": {
       "Properties": {
@@ -2304,7 +2330,9 @@ exports[`DataStack > renders expected template with performance insights 1`] = `
       "Properties": {
         "BackupRetentionPeriod": 1,
         "CopyTagsToSnapshot": true,
-        "DBClusterParameterGroupName": "default.aurora-postgresql15",
+        "DBClusterParameterGroupName": {
+          "Ref": "testdatabasewithinsightsdatabasetestdatabasewithinsightsdatabaseparametergroupD31044B2",
+        },
         "DBSubnetGroupName": {
           "Ref": "testdatabasewithinsightsdatabasetestdatabasewithinsightsdatabaseclusterSubnetsCCC763F0",
         },
@@ -2633,6 +2661,17 @@ exports[`DataStack > renders expected template with performance insights 1`] = `
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Delete",
+    },
+    "testdatabasewithinsightsdatabasetestdatabasewithinsightsdatabaseparametergroupD31044B2": {
+      "Properties": {
+        "Description": "Cluster parameter group for aurora-postgresql15",
+        "Family": "aurora-postgresql15",
+        "Parameters": {
+          "cron.database_name": "crisiscleanup",
+          "shared_preload_libraries": "pg_cron,pg_stat_statements",
+        },
+      },
+      "Type": "AWS::RDS::DBClusterParameterGroup",
     },
     "testdatabasewithinsightsdatabasetestdatabasewithinsightsdatabasesecuritygroup9F838984": {
       "Properties": {


### PR DESCRIPTION
This commit adds a parameter group for Aurora PostgreSQL in the `Database` class of the `stacks/api` package. The parameter group is created with specific parameters, including `shared_preload_libraries` and `cron.database_name`. This change aims to enhance the functionality and performance of the database.

Fixes #